### PR TITLE
Add more general has dep constraint

### DIFF
--- a/example/Media.hs
+++ b/example/Media.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Media where
 
@@ -18,7 +19,7 @@ import Data.Aeson (FromJSON (..), ToJSON (..), defaultOptions, genericParseJSON,
 import Data.Constraint (Dict (..))
 import Data.Kind (Type)
 import Data.Proxy (Proxy (..))
-import Data.Singletons (Apply, type (~>))
+import Data.Singletons (Apply, type (~>), type (@@))
 import Data.Singletons.Sigma (Sigma (..))
 import Data.Singletons.TH (genSingletons)
 import Data.Text (Text)
@@ -26,8 +27,7 @@ import GHC.Generics (Generic)
 import Network.Wai.Handler.Warp (run)
 import Servant.API (Capture, Get, JSON, (:>))
 import Servant.Client (ClientM, client)
-import Servant.Client.Core (RunClient)
-import Servant.Dependent (DepClient (..), DepReqBody, DepServer (DepServer), HasDepClient (..), HasDepServer (..))
+import Servant.Dependent (DepClient (..), DepReqBody, DepServer (DepServer), HasDepConstraint(..))
 import Servant.Server (Application, Handler, serve)
 
 data MediaType
@@ -97,14 +97,8 @@ lookupMedia _identifier =
                 }
     )
 
-instance HasDepServer MkBody MkResponse where
-  hasDepServer _ _ _ s =
-    case s of
-      SBook -> Dict
-      SMovie -> Dict
-
-instance (RunClient m) => HasDepClient MkBody MkResponse m where
-  hasDepClient _ _ _ s =
+instance (con (MkResponse @@ Book), con (MkResponse @@ Movie)) => HasDepConstraint MkResponse con where
+  hasDepConstraint _ _ s = 
     case s of
       SBook -> Dict
       SMovie -> Dict

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "release-24.05",
+        "branch": "release-25.11",
         "description": "Nix Packages collection",
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0da3c44a9460a26d2025ec3ed2ec60a895eb1114",
-        "sha256": "1n435wya14pbl04g6n4zrqaslpik4xq0fv1i2g2mz8sq3dqg7dk0",
+        "rev": "9e1cfa7f745a32223ea4c4513c88be7936a800b6",
+        "sha256": "1nk1w3d5axafaccdmd5cfm4x1g9wcrl2jqf3p6r39kcs5azc41zn",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0da3c44a9460a26d2025ec3ed2ec60a895eb1114.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/9e1cfa7f745a32223ea4c4513c88be7936a800b6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "release-24.05"
     }

--- a/src/Servant/Dependent.hs
+++ b/src/Servant/Dependent.hs
@@ -9,7 +9,9 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -32,21 +34,20 @@ module Servant.Dependent
 
     -- * Combinator
     DepReqBody,
+    HasDepConstraint(..),
 
     -- * Server
     DepServer (..),
-    HasDepServer (..),
 
     -- * Client
     DepClient (..),
-    HasDepClient (..),
   )
 where
 
 import Control.Monad.Trans (liftIO)
 import Control.Monad.Trans.Resource (runResourceT)
 import Data.ByteString.Lazy as BSL
-import Data.Constraint (Dict (..))
+import Data.Constraint (Dict (..), Constraint)
 import Data.Kind (Type)
 import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy (..))
@@ -77,13 +78,14 @@ import Servant.Server.Internal.Router (leafRouter, runRouterEnv)
 -- > type MyApi = "lookup" :> DepReqBody '[JSON] MkBody MkResponse
 data DepReqBody (contentTypes :: [Type]) (body :: ix ~> Type) (route :: ix ~> Type)
 
+-- | Enforce that all potential routes in a `DepReqBody` have the constraint `con`
+-- This is used to provide `HasClient` and `HasServer` instances and certainly can be used for others
+class HasDepConstraint (route :: ix ~> Type) (con :: Type -> Constraint) where
+  hasDepConstraint :: Proxy route -> Proxy con -> Sing (a :: ix) -> Dict (con (route @@ a))
+
 -- | A wrapper around a function that handles routes for all possible @ix@ types
 newtype DepServer (body :: ix ~> Type) (route :: ix ~> Type) (m :: Type -> Type)
   = DepServer (forall (a :: ix). Sing a -> body @@ a -> ServerT (route @@ a) m)
-
--- | A typeclass that captures the `HasServer` instance for all possible routes under the @ix@ types
-class HasDepServer (body :: ix ~> Type) (route :: ix ~> Type) where
-  hasDepServer :: Proxy body -> Proxy route -> Proxy m -> Sing (a :: ix) -> Dict (HasServer (route @@ a) m)
 
 addDepBodyCheck :: Delayed env server -> DelayedIO c -> (c -> DelayedIO sigma) -> Delayed env (sigma, server)
 addDepBodyCheck Delayed {..} newContentD newBodyD =
@@ -109,9 +111,13 @@ runActionM action env req respond k =
     go (FailFatal e) = respond $ FailFatal e
     go (Route a) = let !ka = k a in ka
 
+-- | A typeclass to flip the argument order on `HasServer` so we can use it in conjunction with `HasDepConstraint`
+class HasServer r context => HasServerFlip context r
+instance HasServer r context => HasServerFlip context r
+
 instance
   ( AllCTUnrender contentTypes (Sigma q body),
-    HasDepServer body route,
+    HasDepConstraint route (HasServerFlip context),
     HasContextEntry (MkContextWithErrorFormatter context) ErrorFormatters,
     Typeable body,
     Typeable route,
@@ -125,7 +131,7 @@ instance
   hoistServerWithContext _ pc nt (DepServer f) =
     DepServer
       ( \(s :: Sing a) v ->
-          case hasDepServer (Proxy :: Proxy body) (Proxy :: Proxy route) pc s of
+          case hasDepConstraint (Proxy :: Proxy route) (Proxy :: Proxy (HasServerFlip context)) s of
             Dict ->
               hoistServerWithContext (Proxy :: Proxy (route @@ a)) pc nt (f s v)
       )
@@ -139,7 +145,7 @@ instance
           request
           respond
           ( \((s :: Sing a) :&: v, DepServer subserver) ->
-              case hasDepServer (Proxy :: Proxy body) (Proxy :: Proxy route) (Proxy @context) s of
+              case hasDepConstraint (Proxy :: Proxy route) (Proxy :: Proxy (HasServerFlip context)) s of
                 Dict ->
                   let delayed = emptyDelayed (Route (subserver s v))
                    in runRouterEnv format404 (route (Proxy :: Proxy (route @@ a)) context delayed) env request respond
@@ -169,12 +175,8 @@ instance
 newtype DepClient (body :: ix ~> Type) (route :: ix ~> Type) (m :: Type -> Type)
   = DepClient (forall (a :: ix). Sing a -> body @@ a -> Client m (route @@ a))
 
--- | A typeclass to capture the `HasClient` instances for all possible @ix@ types
-class HasDepClient (body :: ix ~> Type) (route :: ix ~> Type) m where
-  hasDepClient :: Proxy body -> Proxy route -> Proxy m -> Sing (a :: ix) -> Dict (HasClient m (route @@ a))
-
 instance
-  ( HasDepClient body route m,
+  ( HasDepConstraint route (HasClient m),
     RunClient m,
     MimeRender ct (Sigma q body)
   ) =>
@@ -185,7 +187,7 @@ instance
   clientWithRoute pm Proxy req =
     DepClient
       ( \(s :: Sing a) v ->
-          case hasDepClient (Proxy :: Proxy body) (Proxy :: Proxy route) pm s of
+          case hasDepConstraint (Proxy :: Proxy route) (Proxy :: Proxy (HasClient m)) s of
             Dict ->
               clientWithRoute
                 pm
@@ -202,7 +204,7 @@ instance
   hoistClientMonad pm _ f (DepClient run) =
     DepClient
       ( \(s :: Sing a) v ->
-          case hasDepClient (Proxy :: Proxy body) (Proxy :: Proxy route) pm s of
+          case hasDepConstraint (Proxy :: Proxy route) (Proxy :: Proxy (HasClient m)) s of
             Dict ->
               hoistClientMonad pm (Proxy :: Proxy (route @@ a)) f (run s v)
       )
@@ -292,15 +294,15 @@ instance
 -- >      )
 -- >      v
 --
--- Finally we need to provide an instance of `HasDepServer` for our response type to capture
--- the remaining `HasServer` routing information for each possible branch of our index type:
+-- Finally we need to provide an instance of `HasDepConstraint` for our response type to capture
+-- the remaining routing information for each possible branch of our index type:
 --
 -- > import Data.Constraint (Dict(..))
 -- >
 -- > ...
 -- >
--- > instance HasDepServer MkBody MkResponse where
--- >   hasDepServer _ _ _ s =
+-- > instance (con (MkRequest @@ Book), con (MkRequest @@ Movie)) => HasDepConstraint MkResponse con where
+-- >   hasDepConstraint _ _ s =
 -- >     case s of
 -- >       SBook -> Dict
 -- >       SMovie -> Dict
@@ -339,18 +341,8 @@ instance
 -- >       (_, x) ->
 -- >         x
 --
--- And finally we need to provide an instance of `HasDepClient` for our response type to capture
--- the remaining `HasClient` routing information for each possible branch of our index type:
---
--- > import Data.Constraint (Dict(..))
--- >
--- > ...
--- >
--- > instance (RunClient m) => HasDepClient MkBody MkResponse m where
--- >   hasDepClient _ _ _ s =
--- >     case s of
--- >       SBook -> Dict
--- >       SMovie -> Dict
+-- We reuse the same `HasDepConstraint` instance from the server side, which also satisfies
+-- the client's routing constraints.
 --
 -- == Further Reading
 --


### PR DESCRIPTION
I hit a small snag working with Servant Reverse proxy in that I needed to add yet another typeclass call `HasDepReverseProxy` that would prove all dependent branches implemented the `HasReverseProxy`.  The boiler plate was starting to add up as this is very similar to `HasDepServer` and `HasDepClient`.  

I realized we could just have one typeclass to do all the work.  So this PR introduces `HasDepConstraint`.  